### PR TITLE
fixed the DCA license search to limit to Oakland and desired records.…

### DIFF
--- a/processors/scraping/lui/spiders/dca.py
+++ b/processors/scraping/lui/spiders/dca.py
@@ -25,11 +25,14 @@ class DCASpider(scrapy.Spider):
 			'licenseNumber': '',
 			'busName': '',
 			'registryNumber': '',
-			'advBoardCode': '21',
-			'advLicenseType': '43',
+			'advBoardCode': '21,22,25',
+			'advLicenseType': '43,45,51,52,53,54,60,61,73',
+			'advCity': 'OAKLAND2072',
 			'advHasDiscipline': '',
 			'advHasDocuments': ''
 		}
+		print("search_formdata")
+		print(search_formdata)
 
 		# send POST request with the login info
 		yield FormRequest(self.search_url, formdata = search_formdata, callback=self.parse_search_landing)


### PR DESCRIPTION
Fixed the issue with the DCA license search -- the website POST request submits multiple repeated keys as part of the request header, these were all dropped by the Python dictionary used to submit the request. Collapsed the different keys together which seems to replicate the same search results.

@tonyykam 